### PR TITLE
色パネルのデータを曲の種類ごとにビューに表示させる実装（サーバサイド）

### DIFF
--- a/app/assets/stylesheets/_body.scss
+++ b/app/assets/stylesheets/_body.scss
@@ -16,12 +16,14 @@
       // background-color: snow;
       list-style: none;
       display: flex;
-      margin-bottom: 2px;
+      flex-wrap: wrap;
+      width: 617px;
       .color-box {
         background-color: steelblue;
         height: 75px;
         width: 75px;
         margin-right: 2px;
+        margin-bottom: 2px;
         border-radius: 10px;
         &__last {
           background-color: steelblue;
@@ -51,6 +53,8 @@
     }
   }
 }
+
+
 .Nav {
   .nav_box {
     position: fixed;

--- a/app/controllers/songcolors_controller.rb
+++ b/app/controllers/songcolors_controller.rb
@@ -4,10 +4,8 @@ class SongcolorsController < ApplicationController
 
   def index
     @songcolor = Songcolor.new
-    @songcolors = @song.songcolor.select("color")
-
-    # @songcolor = Song.find_by(id:params[:song_id])
-    # @songcolors = Songcolor.find_by(color: @songcolor.color)
+    @songid = Song.find(params[:song_id].to_s)
+    @songcolors = Songcolor.select("color","song_id").where(song_id: @songid)
   end
 
   def new

--- a/app/controllers/songcolors_controller.rb
+++ b/app/controllers/songcolors_controller.rb
@@ -1,23 +1,41 @@
 class SongcolorsController < ApplicationController
+  before_action :set_song
+
 
   def index
-    @songcolors = Songcolor.select("color")
+    @songcolor = Songcolor.new
+    @songcolors = @song.songcolor.select("color")
+
+    # @songcolor = Song.find_by(id:params[:song_id])
+    # @songcolors = Songcolor.find_by(color: @songcolor.color)
   end
 
   def new
-    @songcolor = Songcolor.new
-    @songcolors = Songcolor.select("color")
   end
 
 
   def create
-    Songcolor.create(songcolor_params)
+    @songcolor = Songcolor.create(color: params[:color], song_id: params[:song_id])
+    # if @songcolor.save
+    #   binding.pry
+    #   redirect_to new_song_songcolor_path(@song), notice: '選択した色が保存されました'
+    # else
+    #   @songcolors = Songcolor.includes(:song)
+    #   flash.now[:alert] = 'カラーピッカーで色を選択してください'
+    #   render :new
+    # end
   end
 
+  
+  
   private
 
   def songcolor_params
     params.permit(:color)
+  end
+
+  def set_song
+    @song = Song.find(params[:song_id])
   end
 
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,4 +1,5 @@
 class Song < ApplicationRecord
+  has_many :songcolors
   # has_many :users_songs
   # has_many :users, through: :users_songs
 

--- a/app/models/songcolor.rb
+++ b/app/models/songcolor.rb
@@ -1,5 +1,5 @@
 class Songcolor < ApplicationRecord
-  # belongs_to :song
+  belongs_to :song
   # belongs_to :user
 
   validates :color, presence: true, uniqueness: true

--- a/app/views/songcolors/_body.html.haml
+++ b/app/views/songcolors/_body.html.haml
@@ -3,3 +3,16 @@
     %lu.left-box__colors-fild
       - @songcolors.each do |songcolor|
         %li.color-box{style: "background-color:#{songcolor.color}"}
+        
+  %div.right-box
+    .right-box__disc
+    .right-box__form-box
+      -# .song_index
+      -#   - @songs.each do |song|
+      -#     %div
+      -#       = song.name
+      -#       = link_to '削除', song_path(song.id), method: :delete
+      -#       -# エラー時はlink_toをbutton_toにかえるのも良い
+      -#   -# %a.btn{:href => "/"} topへ戻る
+      -#   = link_to "新規投稿", new_song_path, method: :get, class:"back-btn"
+

--- a/app/views/songcolors/_body.html.haml
+++ b/app/views/songcolors/_body.html.haml
@@ -1,8 +1,6 @@
 .Main
   %div.left-box
-    %lu.left-box__colors-fild
-      - @songcolors.each do |songcolor|
-        %li.color-box{style: "background-color:#{songcolor.color}"}
+    = render "songcolors"
         
   %div.right-box
     .right-box__disc

--- a/app/views/songcolors/_colorbtn.html.haml
+++ b/app/views/songcolors/_colorbtn.html.haml
@@ -1,7 +1,7 @@
 .Color
   .colorbtn
     .colorForm
-      = form_with model: [@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
+      = form_with model: [@song,@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
         .colorForm__contents
           = f.color_field :color, id:"colorid", name:"color", class: 'colorForm__input'
         = f.submit '送信', class: 'colorForm__submit'

--- a/app/views/songcolors/_songcolors.html.haml
+++ b/app/views/songcolors/_songcolors.html.haml
@@ -1,0 +1,3 @@
+%lu.left-box__colors-fild
+  - @songcolors.each do |songcolor|
+    %li.color-box{style: "background-color:#{songcolor.color}"}

--- a/app/views/songcolors/create.html.haml
+++ b/app/views/songcolors/create.html.haml
@@ -1,4 +1,4 @@
 %h3
   色の投稿完了しました。
 .back
-  = link_to "一覧へもどる", new_songcolor_path, method: :get, class:"back-btn" 
+  = link_to "一覧へもどる",  song_songcolors_path, method: :get, class:"back-btn" 

--- a/app/views/songcolors/index.html.haml
+++ b/app/views/songcolors/index.html.haml
@@ -1,7 +1,4 @@
-.Main
-  %div.left-box
-    %lu.left-box__colors-fild
-      - @songcolors.each do |songcolor|
-        %li.color-box{style: "background-color:#{songcolor.color}"}
-
-        -# このページ要らなければ消す
+.wrapper
+  = render "body"
+  = render "header"
+  = render "colorbtn"

--- a/app/views/songcolors/index.html.haml
+++ b/app/views/songcolors/index.html.haml
@@ -3,3 +3,5 @@
     %lu.left-box__colors-fild
       - @songcolors.each do |songcolor|
         %li.color-box{style: "background-color:#{songcolor.color}"}
+
+        -# このページ要らなければ消す

--- a/app/views/songcolors/new.html.haml
+++ b/app/views/songcolors/new.html.haml
@@ -1,4 +1,0 @@
-.wrapper
-  = render "body"
-  = render "header"
-  = render "colorbtn"

--- a/app/views/songs/_body.html.haml
+++ b/app/views/songs/_body.html.haml
@@ -99,6 +99,8 @@
 
   %div.right-box
     .right-box__disc
+      お気に入りの曲を登録してください！
+      = link_to "新規投稿", new_song_path, method: :get, class:"back-btn"
     .right-box__form-box
       .song_index
         - @songs.each do |song|
@@ -107,4 +109,4 @@
             = link_to '削除', song_path(song.id), method: :delete
             -# エラー時はlink_toをbutton_toにかえるのも良い
         -# %a.btn{:href => "/"} topへ戻る
-        = link_to "新規投稿", new_song_path, method: :get, class:"back-btn"
+        -# = link_to "新規投稿", new_song_path, method: :get, class:"back-btn"

--- a/app/views/songs/_colorbtn.html.haml
+++ b/app/views/songs/_colorbtn.html.haml
@@ -1,7 +1,9 @@
-.Color
-  .colorbtn
-    .colorForm
-      = form_with model: [@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
-        .colorForm__contents
-          = f.color_field :color, id:"colorid", name:"color", class: 'colorForm__input'
-        = f.submit '送信', class: 'colorForm__submit'
+-# .Color
+-#   .colorbtn
+-#     .colorForm
+-#       = form_with model: [@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
+-#         .colorForm__contents
+-#           = f.color_field :color, id:"colorid", name:"color", class: 'colorForm__input'
+-#         = f.submit '送信', class: 'colorForm__submit'
+
+-# songで読み込んでないなら消すファイル

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   
   root "songs#index"
   resources :users, only: [:edit, :update]
-  resources :songs, only: [:new, :create, :destroy]
-  resources :songcolors, only: [:index, :new, :create]
+  resources :songs, only: [:new, :create, :destroy] do
+    resources :songcolors, only: [:index, :new, :create]
+  end
 end

--- a/db/migrate/20200801063906_create_songcolors.rb
+++ b/db/migrate/20200801063906_create_songcolors.rb
@@ -2,11 +2,10 @@ class CreateSongcolors < ActiveRecord::Migration[6.0]
   def change
     create_table :songcolors do |t|
       t.string :color,               null: false
+      t.references :song, foreign_key: true
       # t.string :colortitle,               null: false
       # t.text :comment
       # t.references :user, foreign_key: true
-      # t.references :song, foreign_key: true
-
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,8 +17,10 @@ ActiveRecord::Schema.define(version: 2020_08_01_063906) do
 
   create_table "songcolors", force: :cascade do |t|
     t.string "color", null: false
+    t.bigint "song_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["song_id"], name: "index_songcolors_on_song_id"
   end
 
   create_table "songs", force: :cascade do |t|
@@ -50,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_08_01_063906) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "songcolors", "songs"
   add_foreign_key "user_songs", "songs"
   add_foreign_key "user_songs", "users"
 end


### PR DESCRIPTION
# What
カラーパネルで登録した色に曲のidを外部キーで持たせておいたのでそれを利用して、
今回は色パネルのデータを曲の種類ごとにビューに表示させる実装をした。

(前回のプルリクでカラーパネルで選択し保存した色データ(Hex値)をビューに表示させた。)

# Why
曲のごとに色のイメージを投稿し、複数のユーザーとイメージを共有するため。