### PR TITLE
親子テーブル（songsとsongcolors）での削除機能の実装（サーバサイド）

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,5 +1,5 @@
 class Song < ApplicationRecord
-  has_many :songcolors
+  has_many :songcolors, dependent: :destroy
   # has_many :users_songs
   # has_many :users, through: :users_songs
 


### PR DESCRIPTION
# What
親モデルを削除する際、その親モデルに紐づく子モデルも削除できるようにしました。
（今回は曲を削除したらそれに紐づく色データも消えるようにしました。）

# Why
上記の機能（dependent: :destroy）をつけないと、親モデルのみの削除ができずエラーが出るため。