### PR TITLE
カラー送信ボタンの相対位置を変更（フロント）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.6.5'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.1'
 # Use postgresql as the database for Active Record
-# gem 'pg', '>= 0.18', '< 2.0'
+gem 'pg', '>= 0.18', '< 2.0'
 # ローカルはこれが必要上↑
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
@@ -60,9 +60,9 @@ gem "haml-rails", ">= 1.0", '<= 2.0.1'
  gem 'font-awesome-sass'
  # FontAwesomeを導入
 
- group :production do
-  gem 'pg'
-end
+#  group :production do
+#   gem 'pg'
+# end
 #本番環境にpg gemをインストールしてRailsがPostgreSQLと通信できるようにするローカルでコメントアウト
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.2)
-  pg
+  pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.1)

--- a/app/assets/stylesheets/_body.scss
+++ b/app/assets/stylesheets/_body.scss
@@ -156,13 +156,14 @@ a {
 }
 
 .Color {
+  position: relative;
   .colorbtn {
-    position: fixed;
+    position: absolute;
     background-color: #dadada;
     height: 56px;
     width: 614px;
-    top: 85px;
-    left: 213px;
+    top: 47px;
+    left: -332px;
     padding-left: 25px;
     padding-right: 25px;
     .colorForm {

--- a/app/views/songcolors/_colorbtn.html.haml
+++ b/app/views/songcolors/_colorbtn.html.haml
@@ -1,9 +1,9 @@
-.Color
-  .colorbtn
-    .colorForm
-      .songName
-        song name：「#{@song.name}」
-      = form_with model: [@song,@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
-        .colorForm__contents
-          = f.color_field :color, id:"colorid", name:"color", class: 'colorForm__input'
-        = f.submit 'send', class: 'colorForm__submit'
+-# .Color
+-#   .colorbtn
+-#     .colorForm
+-#       .songName
+-#         song name：「#{@song.name}」
+-#       = form_with model: [@song,@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
+-#         .colorForm__contents
+-#           = f.color_field :color, id:"colorid", name:"color", class: 'colorForm__input'
+-#         = f.submit 'send', class: 'colorForm__submit'

--- a/app/views/songcolors/_header-btn.html.haml
+++ b/app/views/songcolors/_header-btn.html.haml
@@ -4,6 +4,16 @@
       .nav_box__logo-field__logo
         = link_to root_url, method: :get do
           VISUALmusic
+      -# カラー送信ボタンあり
+      .Color
+        .colorbtn
+          .colorForm
+            .songName
+              song name：「#{@song.name}」
+            = form_with model: [@song,@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
+              .colorForm__contents
+                = f.color_field :color, id:"colorid", name:"color", class: 'colorForm__input'
+              = f.submit 'send', class: 'colorForm__submit'
       .nav_box__logo-field__right
         %lu.menu-box
           %li.menu-box__search

--- a/app/views/songcolors/_header.html.haml
+++ b/app/views/songcolors/_header.html.haml
@@ -4,6 +4,18 @@
       .nav_box__logo-field__logo
         = link_to root_url, method: :get do
           VISUALmusic
+      .Color
+        .colorbtn
+          .colorForm
+            .songName
+              song name：「#{@song.name}」
+            = form_with model: [@song,@songcolor], url: {action: "create"}, html: {class: "cForm"}, local: true do |f|
+              .colorForm__contents
+                = f.color_field :color, id:"colorid", name:"color", class: 'colorForm__input'
+              = f.submit 'send', class: 'colorForm__submit'
+
+
+
       .nav_box__logo-field__right
         %lu.menu-box
           %li.menu-box__search

--- a/app/views/songcolors/index.html.haml
+++ b/app/views/songcolors/index.html.haml
@@ -1,4 +1,4 @@
 .wrapper
   = render "body"
-  = render "header"
+  = render "header-btn"
   = render "colorbtn"


### PR DESCRIPTION
# What
カラー送信ボタンの相対位置を変更。

# Why
position: fixed;からposition: relative;とposition: absolute;に変更。
ブラウザを基準に配置していた送信ボタンだとブラウザを縮小した時に送信ボタンのフィールドが中央によってしまうため。