### PR TITLE
READMEのテーブル名アソシエーション関係など訂正

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ VSCode,HTML/CSS, Ruby, Ruby on Rails
 
 
 
-## songs_discsテーブル
+## song_discsテーブル
 
 |Column|Type|Options|
 |------|----|-------|


### PR DESCRIPTION
# What
READMEのテーブル名アソシエーション関係など訂正。

# Why
中間テーブルの名前がsongs_discsという風に単語ごとに複数系になっていたのでsong_discsというように訂正。
また、同時に他のテーブル名も同じ規則で訂正。
アソシエーションの記述訂正。