### PR TITLE
カラーピッカーバーのズレを修正

### DIFF
--- a/app/assets/stylesheets/_body.scss
+++ b/app/assets/stylesheets/_body.scss
@@ -163,7 +163,8 @@ a {
     height: 56px;
     width: 614px;
     top: 47px;
-    left: -332px;
+    // left: -332px;
+    left: -351px;
     padding-left: 25px;
     padding-right: 25px;
     .colorForm {


### PR DESCRIPTION
# What
カラーピッカーバーのズレを修正しました。

# Why
何度か直しているが何かの過程で少しずれることがある。
カラーパネル（オブジェクト）とのズレが生じると見栄えが良く無い。

