### PR TITLE
discとsongの削除機能のリレーション（バックエンド）

### DIFF
--- a/app/models/disc.rb
+++ b/app/models/disc.rb
@@ -1,5 +1,5 @@
 class Disc < ApplicationRecord
-  has_many :song_discs
+  has_many :song_discs, dependent: :destroy
   has_many :songs, through: :song_discs
   validates :name, presence: true
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,7 +1,7 @@
 class Song < ApplicationRecord
   has_many :songcolors, dependent: :destroy
 
-  has_many :song_discs
+  has_many :song_discs, dependent: :destroy
   has_many :discs, through: :song_discs
   validates :name, presence: true
 end


### PR DESCRIPTION
# What
discとsongの削除機能のリレーション

# Why
CDの情報を削除した時、中間テーブルの関連idも削除し、
曲の情報を削除した時にも中間テーブルの関連idが削除される様にしないと中間テーブルのidが増え続けるため。

