### PR TITLE
CD編集ページの削除ボタンと新規登録ページのもどるボタンの実装（フロント）

### DIFF
--- a/app/assets/stylesheets/modules/discs.scss
+++ b/app/assets/stylesheets/modules/discs.scss
@@ -30,6 +30,7 @@ li {
   border: 1px solid #ddd;
   border-radius: 5px;
   box-sizing: border-box;
+  position: relative;
   &__field {
     margin-top: 30px;
     display: flex;
@@ -69,6 +70,11 @@ li {
     border: 1px solid #ddd;
     border-radius: 2px;
     text-align: center;
+  }
+  .under-btn {
+    position: absolute;
+    right: 431px;
+    bottom: 40px;
   }
 }
 

--- a/app/controllers/discs_controller.rb
+++ b/app/controllers/discs_controller.rb
@@ -26,6 +26,10 @@ class DiscsController < ApplicationController
   end
 
   def destroy
+    disc = Disc.find(params[:id])
+    disc.destroy
+
+    redirect_to root_path
   end
 
   private

--- a/app/views/discs/_form.html.haml
+++ b/app/views/discs/_form.html.haml
@@ -19,3 +19,4 @@
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField
       = f.submit class: 'SettingGroupForm__button'
+ 

--- a/app/views/discs/edit.html.haml
+++ b/app/views/discs/edit.html.haml
@@ -3,3 +3,5 @@
 .SettingGroupForm
   %h1 CD編集
   = render partial: 'form', locals: { disc: @disc }
+  .under-btn
+    = link_to 'Delete', disc_path(@disc.id), method: :delete, class: "SettingGroupForm__button"

--- a/app/views/discs/new.html.haml
+++ b/app/views/discs/new.html.haml
@@ -3,3 +3,5 @@
 .SettingGroupForm
   %h1 新規CD作成
   = render partial: 'form', locals: { disc: @disc }
+  .under-btn
+    = link_to 'Back', root_path, class: "SettingGroupForm__button"


### PR DESCRIPTION
# What
CD編集ページの削除ボタンと新規登録ページのもどるボタンをつけました。

# Why
CD編集ページで削除ができる方がいい為。
新規登録ページで登録をやめたい時の為。