### PR TITLE
カラーパネルの並び順を投稿が頭に来るように設定

### DIFF
--- a/app/controllers/songcolors_controller.rb
+++ b/app/controllers/songcolors_controller.rb
@@ -4,7 +4,7 @@ class SongcolorsController < ApplicationController
 
   def index
     @songcolor = Songcolor.new
-    @songcolors = Songcolor.where(song_id: @song)
+    @songcolors = Songcolor.where(song_id: @song).order("created_at DESC")
   end
 
   def new


### PR DESCRIPTION
# What
カラーパネルの並び順を投稿が頭に来るように設定

# Why
最新の投稿をブラウザの上に持って来ることで更新がすぐにわかり、
サイトが活用されているのが伝わりやすいため。