### PR TITLE
CDの編集ページフロント追加実装

### DIFF
--- a/app/assets/stylesheets/modules/discs_edit.scss
+++ b/app/assets/stylesheets/modules/discs_edit.scss
@@ -47,6 +47,13 @@ label {
   margin-right: 10px;
   margin-left: 3px;
 }
-.SettingDiscForm__button {
-  
+
+// 更新ボタン
+.SettingDiscForm__rightField-upDateBtn {
+  margin: 0 0 0 auto;
+  .SettingDiscForm__buttonUP {
+    border: none;
+    background-color: transparent;
+    color: #244765;
+  }
 }

--- a/app/assets/stylesheets/modules/discs_edit.scss
+++ b/app/assets/stylesheets/modules/discs_edit.scss
@@ -7,6 +7,17 @@
       padding: 5rem;
       border: 1px solid #d1d1d1;
       border-radius: 10px;
+      .SettingDiscForm {
+        .CDedit {
+          font-weight: bold;
+          font-size: 20px;
+          text-align: center;
+          margin-bottom: 30px;
+        }
+        .under-btn {
+          text-align: end;
+        }
+      }
     }
     .ShowBackBtn {
       padding: 1rem;
@@ -16,4 +27,26 @@
       border-radius: 10px;
     }
   }
+}
+
+
+// CDフォーム（_form.html.haml）
+.SettingDiscForm__field {
+  display: flex;
+  justify-content: center;
+  padding: 10px 0;
+  .SettingDiscForm__leftField {
+    .SettingDiscForm__label {
+      margin-right: 30px;
+    }
+  }
+}
+
+// 曲名に関して
+label {
+  margin-right: 10px;
+  margin-left: 3px;
+}
+.SettingDiscForm__button {
+  
 }

--- a/app/views/discs/_form.html.haml
+++ b/app/views/discs/_form.html.haml
@@ -3,20 +3,20 @@
     -# %h2 10件のエラーが発生しました
     -# %ul
     -#   %li CDnameを入力してください
-  .SettingGroupForm__field
-    .SettingGroupForm__leftField
-      = f.label :name, "CDの名前", class: 'SettingGroupForm__label'
-    .SettingGroupForm__rightField
-      = f.text_field :name, class: 'SettingGroupForm__input', placeholder: 'CDの名前を入力してください'
-  .SettingGroupForm__field
-    .SettingGroupForm__leftField
-      %label.SettingGroupForm__label CDに入っている曲を選択
-    .SettingGroupForm__rightField
+  .SettingDiscForm__field
+    .SettingDiscForm__leftField
+      = f.label :name, "CDの名前", class: 'SettingDiscForm__label'
+    .SettingDiscForm__rightField
+      = f.text_field :name, class: 'SettingDiscForm__input', placeholder: 'CDの名前を入力してください'
+  .SettingDiscForm__field
+    .SettingDiscForm__leftField
+      %label.SettingDiscForm__label CDに入っている曲を選択
+    .SettingDiscForm__rightField
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
       = f.collection_check_boxes :song_ids, Song.all, :id, :name
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-  .SettingGroupForm__field
-    .SettingGroupForm__leftField
-    .SettingGroupForm__rightField
-      = f.submit class: 'SettingGroupForm__button'
+  .SettingDiscForm__field
+    .SettingDiscForm__leftField
+    .SettingDiscForm__rightField
+      = f.submit class: 'SettingDiscForm__button'
  

--- a/app/views/discs/_form.html.haml
+++ b/app/views/discs/_form.html.haml
@@ -17,6 +17,6 @@
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .SettingDiscForm__field
     .SettingDiscForm__leftField
-    .SettingDiscForm__rightField
-      = f.submit class: 'SettingDiscForm__button'
+    .SettingDiscForm__rightField-upDateBtn
+      = f.submit "更新", class: 'SettingDiscForm__buttonUP'
  

--- a/app/views/discs/edit.html.haml
+++ b/app/views/discs/edit.html.haml
@@ -5,7 +5,7 @@
         %h1.CDedit CD編集 
         = render partial: 'form', locals: { disc: @disc }
         .under-btn
-          = link_to 'Delete', disc_path(@disc.id), method: :delete, class: "SettingDiscForm__button"
+          = link_to '削除', disc_path(@disc.id), method: :delete, class: "SettingDiscForm__button"
     .ShowBackBtn
       = link_to "戻る", disc_path
 

--- a/app/views/discs/edit.html.haml
+++ b/app/views/discs/edit.html.haml
@@ -1,11 +1,11 @@
 .DiscEditBace
   .DiscEditBace_box
     .DiscEdit
-      .SettingGroupForm
-        %h1 CD編集
+      .SettingDiscForm
+        %h1.CDedit CD編集 
         = render partial: 'form', locals: { disc: @disc }
         .under-btn
-          = link_to 'Delete', disc_path(@disc.id), method: :delete, class: "SettingGroupForm__button"
+          = link_to 'Delete', disc_path(@disc.id), method: :delete, class: "SettingDiscForm__button"
     .ShowBackBtn
       = link_to "戻る", disc_path
 


### PR DESCRIPTION
# What
CDの編集ページフロント追加実装
①ボタンの表示文字
②ボタン位置修正

# Why 
表示を見やすく、統一する為