### PR TITLE
CDの新規登録ページのフロントと登録・更新ボタンの表示を分岐させる実装

### DIFF
--- a/app/assets/stylesheets/modules/discs.scss
+++ b/app/assets/stylesheets/modules/discs.scss
@@ -102,6 +102,7 @@
     margin: 0 auto;
     width: 81.667%;
     padding-top: 100px;
+    padding-bottom: 100px;
     .CategrySpace {
       width: 100%;
       height: 44px;
@@ -136,6 +137,7 @@
   }
 }
 
+// CDの新規登録ボタン
 .Newlink {
   width: 100px;
   height: 100px;
@@ -144,6 +146,8 @@
   position:fixed; 
   bottom: 20px;
   right: 20px;
+  padding: 35px 10px;
+  border-radius: 55px;
   .disc-btn {
     color: white;
   }

--- a/app/views/discs/_form.html.haml
+++ b/app/views/discs/_form.html.haml
@@ -7,7 +7,7 @@
     .SettingDiscForm__leftField
       = f.label :name, "CDの名前", class: 'SettingDiscForm__label'
     .SettingDiscForm__rightField
-      = f.text_field :name, class: 'SettingDiscForm__input', placeholder: 'CDの名前を入力してください'
+      = f.text_field :name, class: 'SettingDiscForm__input', placeholder: 'CDの名前を入力'
   .SettingDiscForm__field
     .SettingDiscForm__leftField
       %label.SettingDiscForm__label CDに入っている曲を選択

--- a/app/views/discs/_form.html.haml
+++ b/app/views/discs/_form.html.haml
@@ -18,5 +18,7 @@
   .SettingDiscForm__field
     .SettingDiscForm__leftField
     .SettingDiscForm__rightField-upDateBtn
-      = f.submit "更新", class: 'SettingDiscForm__buttonUP'
- 
+      - if controller.action_name == "edit"
+        = f.submit "更新", class: 'SettingDiscForm__buttonUP'
+      -else
+        = f.submit "登録", class: 'SettingDiscForm__buttonUP'

--- a/app/views/discs/_makeform.html.haml
+++ b/app/views/discs/_makeform.html.haml
@@ -1,2 +1,4 @@
 .Newlink
-  = link_to "CDの新規登録", new_disc_path, method: :get, class:"disc-btn"
+  = link_to new_disc_path, method: :get, class:"disc-btn" do
+    NewCD
+    = icon('fas', 'compact-disc',class: 'newcd_icon')

--- a/app/views/discs/new.html.haml
+++ b/app/views/discs/new.html.haml
@@ -1,8 +1,13 @@
-.SettingGroupForm
-  %h1 新規CD作成
-  = render partial: 'form', locals: { disc: @disc }
-  .under-btn
-    = link_to 'Back', root_path, class: "SettingGroupForm__button"
+.DiscEditBace
+  .DiscEditBace_box
+    .DiscEdit
+      .SettingDiscForm
+        %h1.CDedit 新規CD作成
+        = render partial: 'form', locals: { disc: @disc }
+        -# .under-btn
+        -#   = link_to 'Back', root_path, class: "SettingGroupForm__button"
+    .ShowBackBtn
+      = link_to "戻る", discs_path
 
 .header-other
   = render 'songcolors/header'


### PR DESCRIPTION
# What
①CDの新規登録ページのフロントを調整（フロント）
②それぞれ（newとeditページの）登録・更新ボタンの表示を分岐させた（バックエンド）

# Why
①見た目を調整する事で、使用しやすさとサイト全体の統一をはかる。
②同じフォームのhamlコードを読み込んで使用していたが、ページによって表示を変えたかったので分岐させた。