### PR TITLE
カラーピッカー の送信ボタンを繰り返し押せるようにする

### DIFF
--- a/app/assets/javascripts/songcolor.js
+++ b/app/assets/javascripts/songcolor.js
@@ -28,6 +28,7 @@ $(function() {
     })
     .done(function(data){
       let html = buildHTML(data);
+      $('.colorForm__submit').prop('disabled', false) //一度押すと押せなくなる送信ボタンを連続で押せるようにしている
       // .prepend指定した要素の最初に、引数で指定した内容を追加
       $('.left-box__colors-fild').prepend(html); 
     })


### PR DESCRIPTION
# What
カラーピッカー の送信ボタンを繰り返し押せるようにする

#Why
一度ボタンを押した後押せないと使用しづらい。
（リロードボタンを毎回押さないといけなくなるため）